### PR TITLE
fix #4 to discover namespace in orgs > 1000 classes

### DIFF
--- a/src/classes/ApexClassSetModel.cls
+++ b/src/classes/ApexClassSetModel.cls
@@ -177,9 +177,9 @@ public class ApexClassSetModel extends ApexDomain.StandardSetModel {
             SELECT NamespacePrefix
             FROM ApexClass
             WHERE NamespacePrefix != 'abstract'
-            AND NamespacePrefix != null
             GROUP BY NamespacePrefix
             HAVING COUNT(Id) < 1000
+            OR NamespacePrefix = null
         ];
         
         Set<String> namespaces = new Set<String>();

--- a/src/classes/ApexClassSetModel.cls
+++ b/src/classes/ApexClassSetModel.cls
@@ -177,6 +177,7 @@ public class ApexClassSetModel extends ApexDomain.StandardSetModel {
             SELECT NamespacePrefix
             FROM ApexClass
             WHERE NamespacePrefix != 'abstract'
+            AND NamespacePrefix != null
             GROUP BY NamespacePrefix
             HAVING COUNT(Id) < 1000
         ];


### PR DESCRIPTION
The existing code won’t find classes with no namespace in the orgs with more than 1000 classes.